### PR TITLE
Update name in package.json & sky-labels.json

### DIFF
--- a/dist/sky-labels.js
+++ b/dist/sky-labels.js
@@ -1,7 +1,7 @@
 /*
  *  SkyLabels.js - v0.0.1
  *  Fun, Compact & Accessible Forms
- *  http://thoughtbot.github.io/slider
+ *  http://thoughtbot.github.io/sky-labels
  *
  *  Made by Paul Smith
  *  Under MIT License

--- a/dist/sky-labels.min.js
+++ b/dist/sky-labels.min.js
@@ -1,7 +1,7 @@
 /*
  *  SkyLabels.js - v0.0.1
  *  Fun, Compact & Accessible Forms
- *  http://thoughtbot.github.io/slider
+ *  http://thoughtbot.github.io/sky-labels
  *
  *  Made by Paul Smith
  *  Under MIT License

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "Slider.js",
-  "title": "Slider.js",
+  "name": "SkyLabels.js",
+  "title": "SkyLabels.js",
   "description": "Fun, Compact & Accessible Forms",
   "author": "Paul Smith",
-  "homepage": "https://github.com/thoughtbot/slider/",
-  "repository": "https://github.com/thoughtbot/slider/",
+  "homepage": "https://github.com/thoughtbot/sky-labels/",
+  "repository": "https://github.com/thoughtbot/sky-labels/",
   "version": "0.0.1",
   "devDependencies": {
     "grunt": "~0.4.4",

--- a/sky-labels.json
+++ b/sky-labels.json
@@ -27,10 +27,10 @@
       "url": "http://opensource.org/licenses/MIT"
     }
   ],
-  "bugs": "https://github.com/thoughtbot/slider/issues",
-  "homepage": "http://thoughtbot.github.io/slider",
-  "docs": "http://thoughtbot.github.io/slider#readme",
-  "download": "https://github.com/thoughtbot/slider/dist/sky-labels.min.js",
+  "bugs": "https://github.com/thoughtbot/sky-labels/issues",
+  "homepage": "http://thoughtbot.github.io/sky-labels",
+  "docs": "http://github.com/sky-labels",
+  "download": "https://github.com/thoughtbot/sky-labels/dist/sky-labels.min.js",
   "dependencies": {
     "jquery": ">=1.4"
   }


### PR DESCRIPTION
Some files still had the old name of the library ("slider"). This commit
updates those files to the new name ("sky-labels")
