### PR TITLE
`setupSkyLabels` accepts a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+master
+------
+
+* `setupSkyLabels` accepts a DOM node, falling back to `document`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ read the following.
 <script src="js/sky-labels.js"></script>
 <!-- Setup events for slide labels -->
 <script type="text/javascript">
-setupSkyLabels();
+setupSkyLabels(document);
 </script>
 ```
 

--- a/src/sky-labels.js
+++ b/src/sky-labels.js
@@ -1,7 +1,11 @@
-var setupSkyLabels = function () {
-  $(document).on("focus blur", ".sky-label", addOrRemoveHasTextClass);
-  $(document).on("focus", ".sky-label", addFocusedClass);
-  $(document).on("blur", ".sky-label", removeFocusedClass);
+var setupSkyLabels = function (node) {
+  if (!node) {
+    node = document;
+  }
+
+  $(node).on("focus blur", ".sky-label", addOrRemoveHasTextClass);
+  $(node).on("focus", ".sky-label", addFocusedClass);
+  $(node).on("blur", ".sky-label", removeFocusedClass);
   $(document).ready(hideLabelsIfInputHasText);
 
   function addFocusedClass(event) {


### PR DESCRIPTION
Allows callers to scope the setup function to a DOM node more specific
than `document`
